### PR TITLE
Follow Buildifier Starlark file detection rules

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,12 +2,14 @@
   name: Buildifier
   entry: run-buildifier.sh
   language: script
+  # For Buildifier's filename detection rules, see
+  # https://github.com/bazelbuild/buildtools/blob/master/buildifier/utils/utils.go
   files: |
     (?x)^(
-      BUILD.bazel|
       BUILD|
       WORKSPACE|
-      .*\.bzl
+      .*\.(bzl|sky|star)|
+      (BUILD|WORKSPACE)\..*\.(bazel|oss)
     )$
   description: Runs Buildifier on Bazel build and workspace files.
   minimum_pre_commit_version: '1'


### PR DESCRIPTION
See [buildifier/utils/utils.go](https://github.com/bazelbuild/buildtools/blob/e6efbf6df90bec363c3cbd564b72be6c8a309f14/buildifier/utils/utils.go#L31-L45):

```go
func isStarlarkFile(name string) bool {
	ext := filepath.Ext(name)
	switch ext {
	case ".bzl", ".sky", ".star":
		return true
	}

	switch ext {
	case ".bazel", ".oss":
		// BUILD.bazel or BUILD.foo.bazel should be treated as Starlark files, same for WORSKSPACE
		return strings.HasPrefix(name, "BUILD.") || strings.HasPrefix(name, "WORKSPACE.")
	}

	return name == "BUILD" || name == "WORKSPACE"
}
```